### PR TITLE
[SRTT-3300] 정산 API 변경사항 반영

### DIFF
--- a/api/src/main/java/com/myrealtrip/ohmyhotel/api/application/common/converter/SingleSearchResponseConverter.java
+++ b/api/src/main/java/com/myrealtrip/ohmyhotel/api/application/common/converter/SingleSearchResponseConverter.java
@@ -1,5 +1,6 @@
 package com.myrealtrip.ohmyhotel.api.application.common.converter;
 
+import com.myrealtrip.ohmyhotel.core.domain.partner.dto.MrtCommissionInfo;
 import com.myrealtrip.ohmyhotel.core.domain.search.dto.RatePlan;
 import com.myrealtrip.ohmyhotel.core.service.BedDescriptionConverter;
 import com.myrealtrip.ohmyhotel.api.protocol.search.RateSearchId;
@@ -54,7 +55,7 @@ public class SingleSearchResponseConverter {
      */
     public SearchResponse toSearchResponse(Long hotelId,
                                            OmhRoomAvailability omhRoomAvailability,
-                                           BigDecimal mrtCommissionRate,
+                                           MrtCommissionInfo mrtCommissionInfo,
                                            int ratePlanCount,
                                            ZeroMargin zeroMargin,
                                            String searchId) {
@@ -63,7 +64,7 @@ public class SingleSearchResponseConverter {
             .providerType(ProviderType.GDS)
             .providerCode(ProviderCode.OH_MY_HOTEL)
             .score(null)
-            .rooms(toRoomAvailabilities(Map.of(omhRoomAvailability.getRoomTypeCode(), List.of(omhRoomAvailability)), mrtCommissionRate, ratePlanCount, zeroMargin))
+            .rooms(toRoomAvailabilities(Map.of(omhRoomAvailability.getRoomTypeCode(), List.of(omhRoomAvailability)), mrtCommissionInfo, ratePlanCount, zeroMargin))
             .build();
 
         return SearchResponse.builder()
@@ -78,22 +79,22 @@ public class SingleSearchResponseConverter {
      */
     public SearchResponse toSearchResponse(Long hotelId,
                                            OmhRoomsAvailabilityResponse omhRoomsAvailabilityResponse,
-                                           BigDecimal mrtCommissionRate,
+                                           MrtCommissionInfo mrtCommissionInfo,
                                            int ratePlanCount,
                                            ZeroMargin zeroMargin) {
         return SearchResponse.builder()
             .searchId(ProviderCode.OH_MY_HOTEL.name())
             .providerCode(ProviderCode.OH_MY_HOTEL)
-            .properties(toPropertyAvailabilities(hotelId, omhRoomsAvailabilityResponse, mrtCommissionRate, ratePlanCount, zeroMargin))
+            .properties(toPropertyAvailabilities(hotelId, omhRoomsAvailabilityResponse, mrtCommissionInfo, ratePlanCount, zeroMargin))
             .build();
     }
 
     private List<PropertyAvailability> toPropertyAvailabilities(Long hotelId,
                                                                 OmhRoomsAvailabilityResponse omhHotelsAvailabilityResponse,
-                                                                BigDecimal mrtCommissionRate,
+                                                                MrtCommissionInfo mrtCommissionInfo,
                                                                 int ratePlanCount,
                                                                 ZeroMargin zeroMargin) {
-        PropertyAvailability propertyAvailability = toPropertyAvailability(hotelId, omhHotelsAvailabilityResponse, mrtCommissionRate, ratePlanCount, zeroMargin);
+        PropertyAvailability propertyAvailability = toPropertyAvailability(hotelId, omhHotelsAvailabilityResponse, mrtCommissionInfo, ratePlanCount, zeroMargin);
         if (CollectionUtils.isEmpty(propertyAvailability.getRooms())) {
             return Collections.emptyList();
         }
@@ -102,7 +103,7 @@ public class SingleSearchResponseConverter {
 
     private PropertyAvailability toPropertyAvailability(Long hotelId,
                                                         OmhRoomsAvailabilityResponse omhRoomsAvailabilityResponse,
-                                                        BigDecimal mrtCommissionRate,
+                                                        MrtCommissionInfo mrtCommissionInfo,
                                                         int ratePlanCount,
                                                         ZeroMargin zeroMargin) {
         return PropertyAvailability.builder()
@@ -110,32 +111,32 @@ public class SingleSearchResponseConverter {
             .providerType(ProviderType.GDS)
             .providerCode(ProviderCode.OH_MY_HOTEL)
             .score(null)
-            .rooms(toRoomAvailabilities(omhRoomsAvailabilityResponse.getRoomsGroupByRoomTypeCode(), mrtCommissionRate, ratePlanCount, zeroMargin))
+            .rooms(toRoomAvailabilities(omhRoomsAvailabilityResponse.getRoomsGroupByRoomTypeCode(), mrtCommissionInfo, ratePlanCount, zeroMargin))
             .build();
     }
 
     private List<RoomAvailability> toRoomAvailabilities(Map<String, List<OmhRoomAvailability>> roomsGroupByRoomTypeCode,
-                                                        BigDecimal mrtCommissionRate,
+                                                        MrtCommissionInfo mrtCommissionInfo,
                                                         int ratePlanCount,
                                                         ZeroMargin zeroMargin) {
         if (MapUtils.isEmpty(roomsGroupByRoomTypeCode)) {
             return Collections.emptyList();
         }
         return roomsGroupByRoomTypeCode.keySet().stream()
-            .map(roomTypeCode -> toRoomAvailability(roomsGroupByRoomTypeCode.get(roomTypeCode), mrtCommissionRate, ratePlanCount, zeroMargin))
+            .map(roomTypeCode -> toRoomAvailability(roomsGroupByRoomTypeCode.get(roomTypeCode), mrtCommissionInfo, ratePlanCount, zeroMargin))
             .filter(roomAvailability -> CollectionUtils.isNotEmpty(roomAvailability.getRates()))
             .sorted(CommonSearchResponseConverter.ROOM_COMPARATOR)
             .collect(Collectors.toList());
     }
 
     private RoomAvailability toRoomAvailability(List<OmhRoomAvailability> omhRoomAvailabilities,
-                                                BigDecimal mrtCommissionRate,
+                                                MrtCommissionInfo mrtCommissionInfo,
                                                 int ratePlanCount,
                                                 ZeroMargin zeroMargin) {
         return RoomAvailability.builder()
             .roomId(omhRoomAvailabilities.get(0).getRoomTypeCode())
             .roomName(commonSearchResponseConverter.toUnionStayRoomName(omhRoomAvailabilities.get(0).getRoomTypeName(), omhRoomAvailabilities.get(0).getRoomTypeNameByLanguage()))
-            .rates(toRateAvailabilities(omhRoomAvailabilities, mrtCommissionRate, ratePlanCount, zeroMargin))
+            .rates(toRateAvailabilities(omhRoomAvailabilities, mrtCommissionInfo, ratePlanCount, zeroMargin))
             .benefits(toRoomBenefit(omhRoomAvailabilities.get(0)))
             .build();
     }
@@ -156,7 +157,7 @@ public class SingleSearchResponseConverter {
     }
 
     private List<RateAvailability> toRateAvailabilities(List<OmhRoomAvailability> omhRoomAvailabilities,
-                                                        BigDecimal mrtCommissionRate,
+                                                        MrtCommissionInfo mrtCommissionInfo,
                                                         int ratePlanCount,
                                                         ZeroMargin zeroMargin) {
         if (CollectionUtils.isEmpty(omhRoomAvailabilities)) {
@@ -176,13 +177,13 @@ public class SingleSearchResponseConverter {
         return omhRoomAvailabilities.stream()
             .filter(omhRoomAvailability -> isNull(omhRoomAvailability.getTotalMspAmount()) &&
                                            exposeRatePlanCode.contains(omhRoomAvailability.getRatePlanCode()))
-            .map(omhRoomSimpleAvailability -> toRateAvailability(omhRoomSimpleAvailability, mrtCommissionRate, zeroMargin))
+            .map(omhRoomSimpleAvailability -> toRateAvailability(omhRoomSimpleAvailability, mrtCommissionInfo, zeroMargin))
             .sorted(CommonSearchResponseConverter.RATE_COMPARATOR)
             .limit(ratePlanCount)
             .collect(Collectors.toList());
     }
 
-    private RateAvailability toRateAvailability(OmhRoomAvailability omhRoomAvailability, BigDecimal mrtCommissionRate, ZeroMargin zeroMargin) {
+    private RateAvailability toRateAvailability(OmhRoomAvailability omhRoomAvailability, MrtCommissionInfo mrtCommissionInfo, ZeroMargin zeroMargin) {
 
         return RateAvailability.builder()
             .rateId(omhRoomAvailability.getRatePlanCode())
@@ -192,16 +193,16 @@ public class SingleSearchResponseConverter {
             .saleScenario(null)
             .benefits(commonSearchResponseConverter.toRateBenefits(omhRoomAvailability.getMealBasisCode()))
             .beds(toBeds(omhRoomAvailability))
-            .cancelPolicies(commonSearchResponseConverter.toCancelPolicies(omhRoomAvailability.getCancellationPolicy(), mrtCommissionRate))
+            .cancelPolicies(commonSearchResponseConverter.toCancelPolicies(omhRoomAvailability.getCancellationPolicy(), mrtCommissionInfo.getCommissionRate()))
             .totalPayment(zeroMargin.isOn() ?
-                          commonSearchResponseConverter.toZeroMarginTotalPayment(omhRoomAvailability.getTotalNetAmount(), mrtCommissionRate, zeroMargin) :
-                          commonSearchResponseConverter.toTotalPayment(omhRoomAvailability.getTotalNetAmount(), mrtCommissionRate))
-            .commissions(commonSearchResponseConverter.toCommissions(omhRoomAvailability.getTotalNetAmount(), mrtCommissionRate))
-            .surCharges(commonSearchResponseConverter.toSurcharges(omhRoomAvailability.getTotalNetAmount(), mrtCommissionRate, zeroMargin))
+                          commonSearchResponseConverter.toZeroMarginTotalPayment(omhRoomAvailability.getTotalNetAmount(), mrtCommissionInfo.getCommissionRate(), zeroMargin) :
+                          commonSearchResponseConverter.toTotalPayment(omhRoomAvailability.getTotalNetAmount(), mrtCommissionInfo.getCommissionRate()))
+            .commissions(commonSearchResponseConverter.toCommissions(omhRoomAvailability.getTotalNetAmount(), mrtCommissionInfo.getCommissionRate()))
+            .surCharges(commonSearchResponseConverter.toSurcharges(omhRoomAvailability.getTotalNetAmount(), mrtCommissionInfo.getCommissionRate(), zeroMargin))
             .onSiteSurCharges(Collections.emptyList())
             .monetaryPromotions(Collections.emptyList())
             .mrtPromotions(zeroMargin.isOn() ?
-                           commonSearchResponseConverter.toZeroMarginMrtPromotions(omhRoomAvailability.getTotalNetAmount(), mrtCommissionRate, zeroMargin) :
+                           commonSearchResponseConverter.toZeroMarginMrtPromotions(omhRoomAvailability.getTotalNetAmount(), mrtCommissionInfo.getCommissionRate(), zeroMargin) :
                            Collections.emptyList())
             .extraBeds(0)
             .representInclusions(Collections.emptyList())
@@ -212,6 +213,7 @@ public class SingleSearchResponseConverter {
             .recommendOption(null)
             .applyOptionStartDate(null)
             .applyOptionEndDate(null)
+            .saleCommissionPolicyId(String.valueOf(mrtCommissionInfo.getSaleCommissionPolicyId()))
             .build();
     }
 

--- a/api/src/main/java/com/myrealtrip/ohmyhotel/api/application/reservation/OrderSearchService.java
+++ b/api/src/main/java/com/myrealtrip/ohmyhotel/api/application/reservation/OrderSearchService.java
@@ -2,6 +2,7 @@ package com.myrealtrip.ohmyhotel.api.application.reservation;
 
 
 import com.myrealtrip.ohmyhotel.api.application.reservation.converter.PreCheckRequestConverter;
+import com.myrealtrip.ohmyhotel.core.domain.partner.dto.MrtCommissionInfo;
 import com.myrealtrip.ohmyhotel.core.service.reservation.ReservationApiLogService;
 import com.myrealtrip.ohmyhotel.api.application.reservation.converter.OrderConverter;
 import com.myrealtrip.ohmyhotel.api.application.common.converter.SearchRequestConverter;
@@ -74,14 +75,14 @@ public class OrderSearchService {
         OmhPreCheckResponse omhPreCheckResponse = omhPreCheckAgent.preCheck(omhPreCheckRequest);
         orderedRoomAvailability.changeTotalNetAmount(omhPreCheckResponse.getAmount().getTotalNetAmount());
 
-        BigDecimal mrtCommissionRate = commissionRateService.getMrtCommissionRate();
+        MrtCommissionInfo mrtCommissionInfo = commissionRateService.getMrtCommissionInfo();
         ZeroMargin zeroMargin = zeroMarginSearchService.getZeroMargin(hotelId, true);
-        Order order = saveOrder(searchRequest, mrtCommissionRate, orderedRoomAvailability, zeroMargin);
+        Order order = saveOrder(searchRequest, mrtCommissionInfo.getCommissionRate(), orderedRoomAvailability, zeroMargin);
         saveApiLog(order.getOrderId(), omhRoomsAvailabilityRequest, omhRoomsAvailabilityResponse, omhPreCheckRequest, omhPreCheckResponse);
         return singleSearchResponseConverter.toSearchResponse(
             hotelId,
             orderedRoomAvailability,
-            mrtCommissionRate,
+            mrtCommissionInfo,
             searchRequest.getRatePlanCount(),
             zeroMargin,
             String.valueOf(order.getOrderId())

--- a/api/src/test/java/com/myrealtrip/ohmyhotel/api/application/reservation/OrderSearchServiceTest.java
+++ b/api/src/test/java/com/myrealtrip/ohmyhotel/api/application/reservation/OrderSearchServiceTest.java
@@ -2,6 +2,7 @@ package com.myrealtrip.ohmyhotel.api.application.reservation;
 
 import com.google.common.collect.Lists;
 import com.myrealtrip.ohmyhotel.api.application.reservation.converter.PreCheckRequestConverter;
+import com.myrealtrip.ohmyhotel.core.domain.partner.dto.MrtCommissionInfo;
 import com.myrealtrip.ohmyhotel.core.service.BedDescriptionConverter;
 import com.myrealtrip.ohmyhotel.core.service.MealBasisCodeConverter;
 import com.myrealtrip.ohmyhotel.core.service.RatePlanDistinctService;
@@ -173,8 +174,8 @@ class OrderSearchServiceTest {
         given(omhPreCheckAgent.preCheck(any()))
             .willReturn(omhPreCheckResponse);
 
-        given(commissionRateService.getMrtCommissionRate())
-            .willReturn(BigDecimal.valueOf(20));
+        given(commissionRateService.getMrtCommissionInfo())
+            .willReturn(new MrtCommissionInfo(BigDecimal.valueOf(20), 1L));
 
         given(zeroMarginSearchService.getZeroMargin(any(), anyBoolean()))
             .willReturn(ZeroMargin.empty());

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ subprojects {
         // mrt3-common
         implementation("com.myrealtrip.common:mrt3-common:${mrtCommonVersion}")
         // unionstay-common
-        implementation("com.myrealtrip.unionstay-common:unionstay-common:1.3.11.5-SNAPSHOT")
+        implementation("com.myrealtrip.unionstay-common:unionstay-common:1.3.13.1-SNAPSHOT")
 
         // 단위 테스트는 JUnit 5를 사용합니다.
         testImplementation("org.junit.jupiter:junit-jupiter")

--- a/core/src/main/java/com/myrealtrip/ohmyhotel/core/config/cache/CacheProperties.java
+++ b/core/src/main/java/com/myrealtrip/ohmyhotel/core/config/cache/CacheProperties.java
@@ -13,6 +13,7 @@ public class CacheProperties {
     public enum CacheName {
         ROOM_META("room_meta"),
         HOTELS_AVAILABILITY("multiple_availability"),
+        MRT_COMMISSION_INFO("mrt_commission_info"),
         ;
 
         private final String cacheKeyType;
@@ -39,6 +40,7 @@ public class CacheProperties {
     @Getter
     @AllArgsConstructor
     public enum LocalCache {
+        MRT_COMMISSION_INFO(CacheName.MRT_COMMISSION_INFO, 30L, TimeUnit.SECONDS),
         ;
 
         private static final String LOCAL_CACHE_KEY_FORMAT = "%s:%s:%s";  // ex. unionstay:{cacheName}:{key}

--- a/core/src/main/java/com/myrealtrip/ohmyhotel/core/domain/partner/dto/MrtCommissionInfo.java
+++ b/core/src/main/java/com/myrealtrip/ohmyhotel/core/domain/partner/dto/MrtCommissionInfo.java
@@ -1,7 +1,5 @@
 package com.myrealtrip.ohmyhotel.core.domain.partner.dto;
 
-import com.myrealtrip.ohmyhotel.core.domain.ModifyInfo;
-import com.myrealtrip.ohmyhotel.enumarate.PartnerCommissionType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -14,15 +12,11 @@ import java.math.BigDecimal;
 
 @Getter
 @ToString
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SuperBuilder(toBuilder = true)
-public class Partner extends ModifyInfo {
-
-    private Long partnerId;
-
-    private PartnerCommissionType commissionType;
+@SuperBuilder
+public class MrtCommissionInfo {
 
     private BigDecimal commissionRate;
 

--- a/core/src/main/java/com/myrealtrip/ohmyhotel/core/domain/partner/entity/PartnerEntity.java
+++ b/core/src/main/java/com/myrealtrip/ohmyhotel/core/domain/partner/entity/PartnerEntity.java
@@ -35,4 +35,7 @@ public class PartnerEntity extends BaseEntity {
 
     @Column(name = "commission_rate")
     private BigDecimal commissionRate;
+
+    @Column(name = "sale_commission_policy_id")
+    private Long saleCommissionPolicyId;
 }

--- a/core/src/main/java/com/myrealtrip/ohmyhotel/core/service/CommissionRateService.java
+++ b/core/src/main/java/com/myrealtrip/ohmyhotel/core/service/CommissionRateService.java
@@ -1,9 +1,13 @@
 package com.myrealtrip.ohmyhotel.core.service;
 
+import com.myrealtrip.ohmyhotel.core.config.cache.annotation.LocalCacheable;
 import com.myrealtrip.ohmyhotel.core.domain.partner.dto.MrtCommissionInfo;
 import com.myrealtrip.ohmyhotel.core.domain.partner.dto.Partner;
 import com.myrealtrip.ohmyhotel.core.provider.partner.PartnerProvider;
+import com.myrealtrip.ohmyhotel.outbound.agent.mrt.settle.SettleConfigAgent;
+import com.myrealtrip.settle.web.values.SaleCommissionPolicyInquiryResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +16,7 @@ import java.math.BigDecimal;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class CommissionRateService {
 
     @Value("${ohmyhotel.partner-id}")
@@ -19,14 +24,38 @@ public class CommissionRateService {
 
     private final PartnerProvider partnerProvider;
 
-    @Transactional(readOnly = true)
-    public BigDecimal getMrtCommissionRate() {
-        return partnerProvider.getByPartnerId(partnerId).getCommissionRate();
-    }
+    private final SettleConfigAgent settleConfigAgent;
 
     @Transactional
+    public BigDecimal getMrtCommissionRate() {
+        return getMrtCommissionInfo().getCommissionRate();
+    }
+
+    /**
+     * 정산 API 로 부터 커미션 설정을 가져온다.
+     * 실패할 경우 DB 에 저장해둔 백업본을 사용한다.
+     * @return
+     */
+    @Transactional
     public MrtCommissionInfo getMrtCommissionInfo() {
-        Partner partner =  partnerProvider.getByPartnerId(partnerId);
-        return new MrtCommissionInfo(partner.getCommissionRate(), partner.getSaleCommissionPolicyId());
+        MrtCommissionInfo mrtCommissionInfo;
+        try {
+            mrtCommissionInfo = getMrtCommissionInfoFromSettlementApi();
+        } catch (Throwable t) {
+            log.error("settle api error", t);
+            Partner partner =  partnerProvider.getByPartnerId(partnerId);
+            return new MrtCommissionInfo(partner.getCommissionRate(), -1L);
+        }
+
+        if (mrtCommissionInfo.getSaleCommissionPolicyId() == -1) {
+            Partner partner =  partnerProvider.getByPartnerId(partnerId);
+            return new MrtCommissionInfo(partner.getCommissionRate(), -1L);
+        }
+        return mrtCommissionInfo;
+    }
+
+    private MrtCommissionInfo getMrtCommissionInfoFromSettlementApi() {
+        SaleCommissionPolicyInquiryResponse response = settleConfigAgent.getSettlementConfig(String.valueOf(partnerId));
+        return new MrtCommissionInfo(response.getCommissionRate(), response.getSaleCommissionPolicyId());
     }
 }

--- a/core/src/main/java/com/myrealtrip/ohmyhotel/core/service/CommissionRateService.java
+++ b/core/src/main/java/com/myrealtrip/ohmyhotel/core/service/CommissionRateService.java
@@ -1,5 +1,7 @@
 package com.myrealtrip.ohmyhotel.core.service;
 
+import com.myrealtrip.ohmyhotel.core.config.cache.CacheProperties;
+import com.myrealtrip.ohmyhotel.core.config.cache.CacheProperties.LocalCache;
 import com.myrealtrip.ohmyhotel.core.config.cache.annotation.LocalCacheable;
 import com.myrealtrip.ohmyhotel.core.domain.partner.dto.MrtCommissionInfo;
 import com.myrealtrip.ohmyhotel.core.domain.partner.dto.Partner;
@@ -37,6 +39,7 @@ public class CommissionRateService {
      * @return
      */
     @Transactional
+    @LocalCacheable(cache = LocalCache.MRT_COMMISSION_INFO, param = "null", type = MrtCommissionInfo.class)
     public MrtCommissionInfo getMrtCommissionInfo() {
         MrtCommissionInfo mrtCommissionInfo;
         try {

--- a/core/src/main/java/com/myrealtrip/ohmyhotel/core/service/CommissionRateService.java
+++ b/core/src/main/java/com/myrealtrip/ohmyhotel/core/service/CommissionRateService.java
@@ -1,5 +1,6 @@
 package com.myrealtrip.ohmyhotel.core.service;
 
+import com.myrealtrip.ohmyhotel.core.domain.partner.dto.MrtCommissionInfo;
 import com.myrealtrip.ohmyhotel.core.domain.partner.dto.Partner;
 import com.myrealtrip.ohmyhotel.core.provider.partner.PartnerProvider;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +22,11 @@ public class CommissionRateService {
     @Transactional(readOnly = true)
     public BigDecimal getMrtCommissionRate() {
         return partnerProvider.getByPartnerId(partnerId).getCommissionRate();
+    }
+
+    @Transactional
+    public MrtCommissionInfo getMrtCommissionInfo() {
+        Partner partner =  partnerProvider.getByPartnerId(partnerId);
+        return new MrtCommissionInfo(partner.getCommissionRate(), partner.getSaleCommissionPolicyId());
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -66,7 +66,7 @@ mrtCommonVersion=3.0.62
 mrtCipherVersion=0.0.16-SNAPSHOT
 
 # Myrealtrip Settlement
-settlementClientVersion=0.2.2
+settlementClientVersion=0.7.5
 
 # Query DSL
 queryDslVersion=5.0.0

--- a/outbound/src/test/java/com/myrealtrip/ohmyhotel/outbound/agent/mrt/settle/SettleConfigAgentTest.java
+++ b/outbound/src/test/java/com/myrealtrip/ohmyhotel/outbound/agent/mrt/settle/SettleConfigAgentTest.java
@@ -1,6 +1,7 @@
 package com.myrealtrip.ohmyhotel.outbound.agent.mrt.settle;
 
 import com.myrealtrip.ohmyhotel.outbound.AgentTestContext;
+import com.myrealtrip.settle.web.values.SaleCommissionPolicyInquiryResponse;
 import com.myrealtrip.settle.web.values.SettlementConfigResponse;
 import com.myrealtrip.srtcommon.support.utils.ObjectMapperUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,7 @@ class SettleConfigAgentTest {
     void getSettlementConfig() {
         String partnerId = "3147309";
 
-        SettlementConfigResponse response = agent.getSettlementConfig(partnerId);
+        SaleCommissionPolicyInquiryResponse response = agent.getSettlementConfig(partnerId);
 
         log.info("{}", ObjectMapperUtils.writeAsString(response));
     }


### PR DESCRIPTION
- 정산 API 를 실시간으로 호출하여 수수료/policyId 사용하도록 한다.
- 정산 API 가 실패했을 경우 백업본에 저장된 수수료를 사용하고 PolicyId 는 -1 로 세팅한다.